### PR TITLE
27 smtp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,6 @@
 ##
 ##    docker-compose -d up
 ##
-## Admin:
-##
-##   $ docker login docker.steve.fi
-##   $ docker tag dhcp.io:1 docker.steve.fi/steve/dhcp.io:1
-##   $ docker push docker.steve.fi/steve/dhcp.io:1
-##
-##
-## Admin Launching:
-##
-##   $ docker login docker.steve.fi
-##   $ docker pull docker.steve.fi/steve/dhcp.io:1
-##   $ docker-compose -d up
 ##
 
 # Base image
@@ -37,7 +25,7 @@ FROM debian:buster
 RUN apt-get update --quiet
 
 # Perl/Other dependencies
-RUN apt-get install --yes make libhtml-template-perl libcgi-application-perl libtie-ixhash-perl libdata-uuid-libuuid-perl libdbi-perl libdbd-sqlite3-perl libhtml-template-perl libjson-perl libredis-perl perl-modules lighttpd libcgi-session-perl libnet-dns-perl libxml-simple-perl libwww-perl libcrypt-blowfish-perl libcrypt-eksblowfish-perl libtest-pod-perl libtest-strict-perl libtest-www-mechanize-cgiapp-perl
+RUN apt-get install --yes make libhtml-template-perl libcgi-application-perl libtie-ixhash-perl libdata-uuid-libuuid-perl libdbi-perl libdbd-sqlite3-perl libhtml-template-perl libjson-perl libredis-perl perl-modules lighttpd libcgi-session-perl libnet-dns-perl libxml-simple-perl libwww-perl libcrypt-blowfish-perl libcrypt-eksblowfish-perl libtest-pod-perl libtest-strict-perl libtest-www-mechanize-cgiapp-perl libnet-smtp-ssl-perl
 
 # Ensure /root is writable for the tests
 RUN chmod -R 777 /root

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The code relies upon the following modules being present and installed:
   * `apt-get install libhtml-template-perl`
 * JSON
   * `apt-get install libjson-perl`
+* Net::SMTP::SSL
+  * `apt-get install libnet-smtp-ssl-perl`
 * Redis
   * `apt-get install libredis-perl`
 * WebService::Amazon::Route53

--- a/lib/DHCP/Application.pm
+++ b/lib/DHCP/Application.pm
@@ -1368,11 +1368,26 @@ sub forgotten
                             from     => $DHCP::Config::SENDER,
                             token    => $token
                           );
-                open( SENDMAIL,
-                      "|/usr/lib/sendmail -t -f $DHCP::Config::SENDER" ) or
-                  die "Cannot open sendmail: $!";
-                print( SENDMAIL $et->output() );
-                close(SENDMAIL);
+
+                #
+                # Send the email.
+                #
+                my $smtp =
+                  Net::SMTP::SSL->new( $DHCP::Config::SMTP_HOST,
+                                       Port  => $DHCP::Config::SMTP_PORT,
+                                       Debug => 0
+                                     );
+
+                $smtp->auth( $DHCP::Config::SMTP_USERNAME,
+                             $DHCP::Config::SMTP_PASSWORD ) ||
+                  die "Authentication failed!\n";
+
+                $smtp->mail( $FROM . "\n" );
+                $smtp->to( $dat->{ 'email' } );
+                $smtp->data();
+                $smtp->datasend( $et->output() );
+                $smtp->dataend();
+                $smtp->quit;
             }
 
             # Show the result.

--- a/lib/DHCP/Application.pm
+++ b/lib/DHCP/Application.pm
@@ -44,6 +44,11 @@ use CGI::Application::Plugin::Throttle;
 use UUID::Tiny;
 
 #
+# Password reminders need SMTP
+#
+use Net::SMTP::SSL;
+
+#
 #  This is is a sanity-check which will make the failure to follow
 # instructions more explicit to users.
 #
@@ -1382,7 +1387,7 @@ sub forgotten
                              $DHCP::Config::SMTP_PASSWORD ) ||
                   die "Authentication failed!\n";
 
-                $smtp->mail( $FROM . "\n" );
+                $smtp->mail( $DHCP::Config::SENDER . "\n" );
                 $smtp->to( $dat->{ 'email' } );
                 $smtp->data();
                 $smtp->datasend( $et->output() );

--- a/lib/DHCP/Config.pm.example
+++ b/lib/DHCP/Config.pm.example
@@ -113,6 +113,16 @@ our $TTL = 300;
 
 
 #
+# SMTP details are necessary for allowing password resets.
+#
+our $SMTP_HOST     = "smtp.gmail.com";
+our $SMTP_PORT     = 465;
+our $SMTP_USERNAME = "";
+our $SMTP_PASSWORD = "";
+
+
+#
+#
 # Path to our SQLite database
 #
 our $DB_PATH = "/srv/db.db";


### PR DESCRIPTION
This pull-request migrates the sending of our password-reset requests to using `Net::SMTP::SSL` (via gmail), rather than relying upon `/usr/lib/sendmail` being available and correctly configured.

Using an external service makes this easier for deployment via docker.

Once complete this will close #27.
